### PR TITLE
Show Cluster Leaders Correctly With Non-Default Hostname

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -348,10 +348,10 @@ func Join(kubernetesData KubernetesData, awsData AwsData) Snapshot {
 			if v, ok := node.ObjectMeta.Labels["kubernetes.io/role"]; ok && v == "master" {
 				row.IsMaster = true
 			}
-			if haveControllerManagerLeader && strings.HasPrefix(node.Name, controllerManagerLeader) {
+			if haveControllerManagerLeader && strings.HasPrefix(node.ObjectMeta.Labels["kubernetes.io/hostname"], controllerManagerLeader) {
 				row.IsControllerManagerLeader = true
 			}
-			if haveSchedulerLeader && strings.HasPrefix(node.Name, schedulerLeader) {
+			if haveSchedulerLeader && strings.HasPrefix(node.ObjectMeta.Labels["kubernetes.io/hostname"], schedulerLeader) {
 				row.IsSchedulerLeader = true
 			}
 			row.IsCordoned = node.Spec.Unschedulable

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package main
 
 var (
 	Program = "kubesat"
-	Version = "0.2-SNAPSHOT"
+	Version = "0.3-SNAPSHOT"
 )


### PR DESCRIPTION
Hostname change for Kerberos authentication. The label seems to be the only definitive reference to the OS hostname.